### PR TITLE
Move @types/pluralize into dependencies

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@nuxt/typescript-runtime": "^0.4.0",
     "@nuxtjs/pwa": "^3.0.0-beta.20",
+    "@types/pluralize": "^0.0.29",
     "apollo-server-express": "^2.11.0",
     "express": "^4.15.4",
     "firebase-admin": "^8.9.2",
@@ -28,7 +29,6 @@
     "@nuxtjs/vuetify": "^1.11.0",
     "@types/express": "^4.17.3",
     "@types/node": "^13.9.2",
-    "@types/pluralize": "^0.0.29",
     "@vue/test-utils": "^1.0.0-beta.32",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.1.0",


### PR DESCRIPTION
In docker container for production:
```
$ ts-node node_modules/typeorm/cli.js migration:run
Error during migration run:
src/config/NamingStrategy.ts:3:23 - error TS7016: Could not find a declaration file for module 'pluralize'. '/app/web/node_modules/pluralize/pluralize.js' implicitly has an 'any' type.
  Try `npm install @types/pluralize` if it exists or add a new declaration (.d.ts) file containing `declare module 'pluralize';`

3 import pluralize from 'pluralize'
                        ~~~~~~~~~~~

error Command failed with exit code 1.
```